### PR TITLE
Remove random number from poster

### DIFF
--- a/qml/libs/pastebin.js
+++ b/qml/libs/pastebin.js
@@ -13,7 +13,7 @@ function post(message, name, on_success, on_failure) {
     }
 
     args.push("content=" + encodeURIComponent(message));
-    args.push("poster=" + encodeURIComponent(name + " " + Math.random()));
+    args.push("poster=" + encodeURIComponent(name));
     args.push("syntax=text");
 
     var req = new XMLHttpRequest();


### PR DESCRIPTION
There is now a thirty-character limit on the names of posters on paste.ubuntu.com. `Math.random()` returns an ~18 character long number when converted to a string. The name `Ubuntu Touch User` is 17 characters. This ultimately caused our pastes to be rejected.

Fixes #12 