### PR TITLE
reformat logname

### DIFF
--- a/po/logviewer.neothethird.pot
+++ b/po/logviewer.neothethird.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: logviewer.neothethird\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-21 20:52+0000\n"
+"POT-Creation-Date: 2020-01-15 20:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,96 +17,8 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../qml/PrefPage.qml:17 ../qml/MainPage.qml:14
-msgid "Settings"
-msgstr ""
-
-#: ../qml/PrefPage.qml:21
-msgid "Cancel"
-msgstr ""
-
-#: ../qml/PrefPage.qml:30
-msgid "Apply"
-msgstr ""
-
-#: ../qml/PrefPage.qml:53
-msgid "Directory:"
-msgstr ""
-
-#: ../qml/PrefPage.qml:75
-msgid "Filter:"
-msgstr ""
-
-#: ../qml/PrefPage.qml:97
-msgid "Refresh interval (ms):"
-msgstr ""
-
-#: ../qml/PrefPage.qml:124
-msgid "Font size:"
-msgstr ""
-
-#: ../qml/PrefPage.qml:151
-msgid "Pastebin user:"
-msgstr ""
-
-#: ../qml/MainPage.qml:9
-msgid "Ubuntu Touch Logs"
-msgstr ""
-
-#: ../qml/MainPage.qml:19 ../qml/AboutPage.qml:8
+#: ../qml/AboutPage.qml:8 ../qml/MainPage.qml:19
 msgid "About"
-msgstr ""
-
-#: ../qml/MainPage.qml:47
-msgid "No logs found for the set filter"
-msgstr ""
-
-#: ../qml/LogPage.qml:23
-msgid "Back"
-msgstr ""
-
-#: ../qml/LogPage.qml:31
-msgid "Pause"
-msgstr ""
-
-#: ../qml/LogPage.qml:31
-msgid "Start"
-msgstr ""
-
-#: ../qml/LogPage.qml:39
-msgid "Copy"
-msgstr ""
-
-#: ../qml/LogPage.qml:39
-msgid "Select"
-msgstr ""
-
-#: ../qml/LogPage.qml:50
-msgid "PasteBin"
-msgstr ""
-
-#: ../qml/LogPage.qml:95
-msgid "Sending to Pastebin.."
-msgstr ""
-
-#: ../qml/LogPage.qml:109
-msgid "Pastebin Error"
-msgstr ""
-
-#: ../qml/LogPage.qml:109
-msgid "Pastebin Successful"
-msgstr ""
-
-#: ../qml/LogPage.qml:116
-msgid "Error ocurred uploading to Pastebin"
-msgstr ""
-
-#: ../qml/LogPage.qml:117
-msgid "<br>(Copied to clipboard)"
-msgstr ""
-
-#: ../qml/LogPage.qml:123
-msgid "OK"
 msgstr ""
 
 #: ../qml/AboutPage.qml:32 logviewer.neothethird.desktop.in.h:1
@@ -154,4 +66,100 @@ msgstr ""
 
 #: ../qml/AboutPage.qml:95
 msgid "and"
+msgstr ""
+
+#: ../qml/LogPage.qml:22
+msgid "Log"
+msgstr ""
+
+#: ../qml/LogPage.qml:38
+msgid "Back"
+msgstr ""
+
+#: ../qml/LogPage.qml:46
+msgid "Pause"
+msgstr ""
+
+#: ../qml/LogPage.qml:46
+msgid "Start"
+msgstr ""
+
+#: ../qml/LogPage.qml:54
+msgid "Copy"
+msgstr ""
+
+#: ../qml/LogPage.qml:54
+msgid "Select"
+msgstr ""
+
+#: ../qml/LogPage.qml:65
+msgid "PasteBin"
+msgstr ""
+
+#: ../qml/LogPage.qml:110
+msgid "Sending to Pastebin.."
+msgstr ""
+
+#: ../qml/LogPage.qml:124
+msgid "Pastebin Error"
+msgstr ""
+
+#: ../qml/LogPage.qml:124
+msgid "Pastebin Successful"
+msgstr ""
+
+#: ../qml/LogPage.qml:131
+msgid "Error ocurred uploading to Pastebin"
+msgstr ""
+
+#: ../qml/LogPage.qml:132
+msgid "<br>(Copied to clipboard)"
+msgstr ""
+
+#: ../qml/LogPage.qml:138
+msgid "OK"
+msgstr ""
+
+#: ../qml/PrefPage.qml:17 ../qml/MainPage.qml:14
+msgid "Settings"
+msgstr ""
+
+#: ../qml/PrefPage.qml:21
+msgid "Cancel"
+msgstr ""
+
+#: ../qml/PrefPage.qml:30
+msgid "Apply"
+msgstr ""
+
+#: ../qml/PrefPage.qml:53
+msgid "Directory:"
+msgstr ""
+
+#: ../qml/PrefPage.qml:75
+msgid "Filter:"
+msgstr ""
+
+#: ../qml/PrefPage.qml:97
+msgid "Refresh interval (ms):"
+msgstr ""
+
+#: ../qml/PrefPage.qml:124
+msgid "Font size:"
+msgstr ""
+
+#: ../qml/PrefPage.qml:151
+msgid "Pastebin user:"
+msgstr ""
+
+#: ../qml/MainPage.qml:9
+msgid "Ubuntu Touch Logs"
+msgstr ""
+
+#: ../qml/MainPage.qml:47
+msgid "No logs found for the set filter"
+msgstr ""
+
+#: ../qml/MainPage.qml:94
+msgid "file"
 msgstr ""

--- a/qml/LogPage.qml
+++ b/qml/LogPage.qml
@@ -18,7 +18,20 @@ Page {
     property bool isLogging: true
 
     header: PageHeader {
-        title: logname
+        title: i18n.tr("Log")
+
+        height: units.gu(8)
+
+        Label {
+            id: lognameString
+            width: parent.width - units.gu(5) //subtract the left margin from parent width
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: units.gu(1)
+            anchors.leftMargin: units.gu(5)
+            anchors.left: parent.left
+            elide: Text.ElideRight
+            text: logname
+        }
 
         leadingActionBar.actions: Action {
             text: i18n.tr("Back")

--- a/qml/LogPage.qml
+++ b/qml/LogPage.qml
@@ -150,7 +150,8 @@ Page {
             top: logPage.header.bottom
             left: parent.left
             right: parent.right
-            bottom: parent.bottom
+            bottom: navigationArea.top
+            bottomMargin: units.gu(1)
         }
 
         TextEdit {
@@ -169,6 +170,73 @@ Page {
             selectedTextColor: theme.palette.selected.selectionText
             selectionColor: theme.palette.selected.selection
             Component.onCompleted: updateTimer.start();
+        }
+    }
+
+    Rectangle {
+        id: navigationArea
+        width: parent.width
+        height: units.gu(5)
+        color: theme.palette.normal.background
+        anchors.bottom: parent.bottom
+
+        Rectangle {
+            id: dividerRect
+            width: parent.width
+            height: 1
+            color: theme.palette.normal.backgroundSecondaryText
+        }
+
+        Row {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: units.gu(2)
+
+            Icon {
+                width: units.gu(3)
+                height: width
+                name: "media-skip-backward"
+                rotation: 90
+                color: theme.palette.normal.baseText
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: scrollView.flickableItem.contentY = 0
+                }
+            }
+
+            Icon {
+                width: units.gu(3)
+                height: width
+                name: "media-playback-start-rtl"
+                color: theme.palette.normal.baseText
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: scrollView.flickableItem.contentY = scrollView.flickableItem.contentY - scrollView.height*0.95
+                }
+            }
+
+            Icon {
+                width: units.gu(3)
+                height: width
+                name: "media-playback-start"
+                color: theme.palette.normal.baseText
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: scrollView.flickableItem.contentY = scrollView.flickableItem.contentY + scrollView.height*0.95
+                }
+            }
+
+            Icon {
+                width: units.gu(3)
+                height: width
+                name: "media-skip-forward"
+                rotation: 90
+                color: theme.palette.normal.baseText
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: scrollView.flickableItem.contentY = scrollView.flickableItem.contentHeight - scrollView.height
+                }
+            }
         }
     }
 }

--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -74,7 +74,7 @@ Page {
 
                 //create page
                 var pref = {
-                    logname: iname,
+                    logname: iname.replace("application-click-",""),
                     path: preferences.dir + model.fileName,
                     fontSize: FontUtils.sizeToPixels("medium") * preferences.dpFontSize / 10,
                     interval: preferences.interval,
@@ -88,8 +88,10 @@ Page {
 
             ListItemLayout {
                 anchors.centerIn: parent
-
-                title.text:model.fileName.slice(model.fileName.lastIndexOf("/")+1,model.fileName.length)
+                //extract app name and version from log filename
+                //distinguish between app logs and other logs because they do have different name structures
+                title.text: model.fileName.lastIndexOf("_") > 1 ? "v" + model.fileName.split("_")[2].replace(".log","") + " " + model.fileName.split("_")[1] : model.fileName.replace(".log","")
+                subtitle.text: i18n.tr("file") + ": " + model.fileName.slice(model.fileName.lastIndexOf("/")+1,model.fileName.length)
 
                 Icon {
                     width: units.gu(2); height: width


### PR DESCRIPTION
Especially on portrait mode it is almost not possible to view the full logs name. Therefore you can't read the version number. When developing, one might have several versions of an app installed. Then you might end up reading the wrong log.

I did add the log name as a subtitle to the header of the logpage. In the main list view I splitted the name and show version and app name as title, the subtitle holds the full name of the logfile in case one wants to search for it in filemanager.

Main page:

![screenshot20200116_202118071](https://user-images.githubusercontent.com/37637312/72555896-d30bac80-389d-11ea-96de-ab9e4ebbb677.png)

Log page:

![screenshot20200116_202128305](https://user-images.githubusercontent.com/37637312/72555897-d30bac80-389d-11ea-9f4f-7457e7ad8079.png)
